### PR TITLE
probably shouldnt keep that

### DIFF
--- a/virion.yml
+++ b/virion.yml
@@ -1,5 +1,5 @@
 name: DataConfig
 antigen: skymin\config
 api: 4.0.0
-version: SKY
+version: 1.0.0
 author: skymin


### PR DESCRIPTION
An internal build error occurs if a plugin attempts to use a non numerical version for a virion. Happened to my FlyPE plugin PR build and successfully builds after changing the version to numerical values.

Really like this library BTW. Good work!